### PR TITLE
Changes in Makefiles. 

### DIFF
--- a/GamepadCalibrator/MakefileLinux
+++ b/GamepadCalibrator/MakefileLinux
@@ -1,8 +1,3 @@
-# Environment
-CC=g++
-CCC=g++
-CXX=g++
-
 # Constants
 SIMPLEINI_DIR = "/home/mike/repo/simpleini"
 
@@ -11,5 +6,5 @@ INCLUDE_DIR_FLAGS = -I${SIMPLEINI_DIR}
 FLAGS_MUTUAL = -Wall -std=c++11  ${INCLUDE_DIR_FLAGS}
 
 all: 
-	g++ ${FLAGS_MUTUAL} GamepadCalibrator.cpp joystick.cpp -o Calibrator
+	g++ ${FLAGS_MUTUAL} GamepadCalibrator.cpp joystick.cc -o Calibrator
 

--- a/MakefileLinux
+++ b/MakefileLinux
@@ -1,5 +1,4 @@
 # Environment
-CC=g++
 CCC=g++
 CXX=g++
 
@@ -28,11 +27,11 @@ clean:
 	@echo "-------------------------" 
 	rm -rf ${OBJECTDIR}
 
-joystick.o:  joystick.cpp
+joystick.o:  joystick.cc
 	@echo "-------------------------" 
 	mkdir -p ${OBJECTDIR}
 	rm -f "${OBJECTDIR}/$@.d"
-	$(COMPILE.cc) $(FLAGS) -o ${OBJECTDIR}/joystick.o joystick.cpp
+	$(COMPILE.cc) $(FLAGS) -o ${OBJECTDIR}/joystick.o joystick.cc
 
 gamepad_control_module.o:  gamepad_control_module.cpp
 	@echo "-------------------------" 


### PR DESCRIPTION
Убрал  CC=g++. Из-за этого пришлось переименовывать файл подключаемой библиотеки.
Теперь достаточно скачать и запустить.
